### PR TITLE
Usability improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,17 +81,15 @@ const transaction = new TopicMessageSubmitTransaction()
 ```
 
 3. **Build the Session Request Payload**: The `@hashgraph/wallectconnect` library provides a
-   seamless way to prepare the session request payload. Ensure that you set the `RequestType`
-   accurately to match the type of Hedera transaction you've constructed.
+   seamless way to prepare the session request payload.
 
 ```javascript
-import {..., RequestType } from '@hashgraph/sdk'
-import { HederaSessionRequest } from '@hashgraph/wallectconnect'
+import { HederaSessionRequest, networkNameToCAIPChainId } from '@hashgraph/wallectconnect'
 
 const payload = HederaSessionRequest.create({
-  chainId: 'hedera:testnet',
+  chainId: networkNameToCAIPChainId('testnet'), // CAIP-2 Chain ID for testnet
   topic: 'abcdef123456',
-}).buildSignAndExecuteTransactionRequest(RequestType.ConsensusSubmitMessage, transaction)
+}).buildSignAndExecuteTransactionRequest('0.0.1234', transaction)
 ```
 
 4. **Send the Transaction to the Wallet**: With the payload prepared, utilize the WalletConnect

--- a/src/lib/dapp.ts
+++ b/src/lib/dapp.ts
@@ -1,4 +1,4 @@
-import { RequestType, type Transaction } from '@hashgraph/sdk'
+import { type Transaction } from '@hashgraph/sdk'
 import { EngineTypes } from '@walletconnect/types'
 import { transactionToBase64String } from './utils'
 import {
@@ -8,33 +8,37 @@ import {
 } from '../types'
 import { HederaJsonRpcMethods } from './constants'
 
-export function buildSignMessageParams(message: string): HederaSignMessageParams {
+export function buildSignMessageParams(
+  signerAccountId: string,
+  messages: (Uint8Array | string)[],
+): HederaSignMessageParams {
   return {
-    message: Buffer.from(message).toString('base64'),
+    signerAccountId,
+    messages: messages.map((message) => Buffer.from(message).toString('base64')),
   }
 }
 
-function _buildTransactionParams(type: RequestType, transaction: Transaction) {
+function _buildTransactionParams(signerAccountId: string, transaction: Transaction) {
   return {
+    signerAccountId,
     transaction: {
-      type: type.toString(),
       bytes: transactionToBase64String(transaction),
     },
   }
 }
 
 export function buildSignAndExecuteTransactionParams(
-  type: RequestType,
+  signerAccountId: string,
   transaction: Transaction,
 ): HederaSignAndExecuteTransactionParams {
-  return _buildTransactionParams(type, transaction)
+  return _buildTransactionParams(signerAccountId, transaction)
 }
 
 export function buildSignAndReturnTransactionParams(
-  type: RequestType,
+  signerAccountId: string,
   transaction: Transaction,
 ): HederaSignAndReturnTransactionParams {
-  return _buildTransactionParams(type, transaction)
+  return _buildTransactionParams(signerAccountId, transaction)
 }
 
 type HederaSessionRequestOptions = Pick<
@@ -56,32 +60,38 @@ export class HederaSessionRequest {
     return new HederaSessionRequest(options)
   }
 
-  public buildSignAndExecuteTransactionRequest(type: RequestType, transaction: Transaction) {
+  public buildSignAndExecuteTransactionRequest(
+    signerAccountId: string,
+    transaction: Transaction,
+  ) {
     return {
       ...this._buildFixedSessionRequestData(),
       request: {
         method: HederaJsonRpcMethods.SIGN_AND_EXECUTE_TRANSACTION,
-        params: buildSignAndExecuteTransactionParams(type, transaction),
+        params: buildSignAndExecuteTransactionParams(signerAccountId, transaction),
       },
     }
   }
 
-  public buildSignAndReturnTransactionRequest(type: RequestType, transaction: Transaction) {
+  public buildSignAndReturnTransactionRequest(
+    signerAccountId: string,
+    transaction: Transaction,
+  ) {
     return {
       ...this._buildFixedSessionRequestData(),
       request: {
         method: HederaJsonRpcMethods.SIGN_AND_RETURN_TRANSACTION,
-        params: buildSignAndReturnTransactionParams(type, transaction),
+        params: buildSignAndReturnTransactionParams(signerAccountId, transaction),
       },
     }
   }
 
-  public buildSignMessageRequest(message: string) {
+  public buildSignMessageRequest(signerAccountId: string, messages: (Uint8Array | string)[]) {
     return {
       ...this._buildFixedSessionRequestData(),
       request: {
         method: HederaJsonRpcMethods.SIGN_MESSAGE,
-        params: buildSignMessageParams(message),
+        params: buildSignMessageParams(signerAccountId, messages),
       },
     }
   }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,4 +1,4 @@
-import { AccountId, Transaction } from '@hashgraph/sdk'
+import { AccountId, Transaction, LedgerId } from '@hashgraph/sdk'
 
 /**
  * Freezes a transaction if it is not already frozen. Transactions must
@@ -59,4 +59,105 @@ export function transactionToBase64String<T extends Transaction>(transaction: T)
 export function base64StringToTransaction<T extends Transaction>(transactionBytes: string): T {
   const decoded = Buffer.from(transactionBytes, 'base64')
   return Transaction.fromBytes(decoded) as T
+}
+
+/**
+ * A mapping of `LedgerId` to EIP chain id and CAIP-2 network name.
+ * @link https://namespaces.chainagnostic.org/hedera/README
+ * @link https://hips.hedera.com/hip/hip-30
+ * @summary [`LedgerId`, `number` (EIP155 chain id), `string` (CAIP-2 chain id)][]
+ */
+export const LEDGER_ID_MAPPINGS: [LedgerId, number, string][] = [
+  [LedgerId.MAINNET, 295, 'hedera:mainnet'],
+  [LedgerId.TESTNET, 296, 'hedera:testnet'],
+  [LedgerId.PREVIEWNET, 297, 'hedera:previewnet'],
+  [LedgerId.LOCAL_NODE, 298, 'hedera:devnet'],
+]
+const DEFAULT_LEDGER_ID = LedgerId.LOCAL_NODE
+const DEFAULT_EIP = LEDGER_ID_MAPPINGS[3][1]
+const DEFAULT_CAIP = LEDGER_ID_MAPPINGS[3][2]
+
+/**
+ * Converts a EIP chain id to a LedgerId object. If no mapping is found, returns `LedgerId.LOCAL_NODE`.
+ * @param chainId number
+ * @returns `LedgerId`
+ */
+export function EIPChainIdToLedgerId(chainId: number): LedgerId {
+  for (let i = 0; i < LEDGER_ID_MAPPINGS.length; i++) {
+    const [ledgerId, chainId_] = LEDGER_ID_MAPPINGS[i]
+    if (chainId === chainId_) {
+      return ledgerId
+    }
+  }
+  return DEFAULT_LEDGER_ID
+}
+
+/**
+ * Converts a LedgerId object to a EIP chain id. If no mapping is found,
+ * returns the EIP chain id for `LedgerId.LOCAL_NODE`.
+ * @param ledgerId LedgerId
+ * @returns `number`
+ */
+export function ledgerIdToEIPChainId(ledgerId: LedgerId): number {
+  for (let i = 0; i < LEDGER_ID_MAPPINGS.length; i++) {
+    const [ledgerId_, chainId] = LEDGER_ID_MAPPINGS[i]
+    if (ledgerId === ledgerId_) {
+      return chainId
+    }
+  }
+  return DEFAULT_EIP
+}
+
+/**
+ * Converts a network name to a EIP chain id. If no mapping is found,
+ * returns the EIP chain id for `LedgerId.LOCAL_NODE`.
+ * @param networkName string
+ * @returns `number`
+ */
+export function networkNameToEIPChainId(networkName: string): number {
+  const ledgerId = LedgerId.fromString(networkName.toLowerCase())
+  return ledgerIdToEIPChainId(ledgerId)
+}
+
+/**
+ * Converts a CAIP chain id to a LedgerId object. If no mapping is found, returns `LedgerId.LOCAL_NODE`.
+ * @param chainId number
+ * @returns `LedgerId`
+ */
+export function CAIPChainIdToLedgerId(chainId: string): LedgerId {
+  for (let i = 0; i < LEDGER_ID_MAPPINGS.length; i++) {
+    const [ledgerId, _, chainId_] = LEDGER_ID_MAPPINGS[i]
+    if (chainId === chainId_) {
+      return ledgerId
+    }
+  }
+  return DEFAULT_LEDGER_ID
+}
+
+/**
+ * Converts a LedgerId object to a CAIP chain id. If no mapping is found,
+ * returns the CAIP chain id for `LedgerId.LOCAL_NODE`.
+ * @param ledgerId LedgerId
+ * @returns `string`
+ */
+export function ledgerIdToCAIPChainId(ledgerId: LedgerId): string {
+  for (let i = 0; i < LEDGER_ID_MAPPINGS.length; i++) {
+    const [ledgerId_, _, chainId] = LEDGER_ID_MAPPINGS[i]
+    if (ledgerId.toString() === ledgerId_.toString()) {
+      return chainId
+    }
+  }
+  return DEFAULT_CAIP
+}
+
+/**
+ * Converts a network name to a CAIP chain id. If no mapping is found,
+ * returns the CAIP chain id for `LedgerId.LOCAL_NODE`.
+ * @param networkName string
+ * @returns `string`
+ */
+export function networkNameToCAIPChainId(networkName: string): string {
+  const ledgerId = LedgerId.fromString(networkName.toLowerCase())
+  const chainId = ledgerIdToCAIPChainId(ledgerId)
+  return chainId
 }

--- a/src/types/jsonRpcTypes.ts
+++ b/src/types/jsonRpcTypes.ts
@@ -1,8 +1,8 @@
 import { TransactionReceipt, TransactionResponseJSON } from '@hashgraph/sdk'
 
 type TransactionParams = {
+  signerAccountId: string
   transaction: {
-    type: string
     bytes: string // should be a base64 encoded string of a Uint8Array
   }
 }
@@ -20,8 +20,9 @@ export type HederaSignAndReturnTransactionResponse = TransactionParams
 
 /** hedera_signMessage */
 export type HederaSignMessageParams = {
-  message: string
+  signerAccountId: string
+  messages: string[] // should be an array of base64 encoded string of a Uint8Array
 }
 export type HederaSignMessageResponse = {
-  signature: string
+  signatures: string[]
 }

--- a/test/_fixtures/buildSignAndExecuteTransactionParamsResult.json
+++ b/test/_fixtures/buildSignAndExecuteTransactionParamsResult.json
@@ -1,6 +1,6 @@
 {
+  "signerAccountId": "0.0.1234",
   "transaction": {
-    "type": "ConsensusCreateTopic",
     "bytes": "Cj4qPAo4ChkKDAiewtWmBhDIsZGbARIHCAAQABi5YBgAEgYIABAAGAMYgISvXyICCHgyAMIBBzIFCIDO2gMSAA=="
   }
 }

--- a/test/_fixtures/buildSignAndReturnTransactionParamsResult.json
+++ b/test/_fixtures/buildSignAndReturnTransactionParamsResult.json
@@ -1,6 +1,6 @@
 {
+  "signerAccountId": "0.0.1234",
   "transaction": {
-    "type": "ConsensusDeleteTopic",
     "bytes": "CjcqNQoxChkKDAiewtWmBhDIsZGbARIHCAAQABi5YBgAEgYIABAAGAMYgISvXyICCHgyANIBABIA"
   }
 }

--- a/test/_fixtures/buildSignMessageParamsResult.json
+++ b/test/_fixtures/buildSignMessageParamsResult.json
@@ -1,3 +1,4 @@
 {
-  "message": "VGVzdCBtZQ=="
+  "signerAccountId": "0.0.1234",
+  "messages": ["VGVzdCBtZQ=="]
 }

--- a/test/_fixtures/signAndReturnTransactionSuccess.json
+++ b/test/_fixtures/signAndReturnTransactionSuccess.json
@@ -1,6 +1,6 @@
 {
+  "signerAccountId": "0.0.12345",
   "transaction": {
-    "type": "ConsensusCreateTopic",
     "bytes": "CqYBKqMBCjgKGQoMCJ7C1aYGEMixkZsBEgcIABAAGLlgGAASBggAEAAYAxiAhK9fIgIIeDIAwgEHMgUIgM7aAxJnCmUKIQJ4J53yGuPNMGEGJ7HkI+u3QFxUuAOa9VLEtFj7Y6qNMzJAj/sYjPtrDkNcfIc/bRgBABLgFhwlUx2/1bDQqgyF40yxhxRPupYB1VRx/Tr5tNdVvJ3H3Ifn1Wy475jsfeL2/A=="
   }
 }

--- a/test/dapp/HederaSessionRequest.test.ts
+++ b/test/dapp/HederaSessionRequest.test.ts
@@ -1,8 +1,8 @@
 import { RequestType, TopicCreateTransaction, TopicDeleteTransaction } from '@hashgraph/sdk'
-import { HederaJsonRpcMethods, HederaSessionRequest } from '../../src'
+import { HederaJsonRpcMethods, HederaSessionRequest, networkNameToCAIPChainId } from '../../src'
 import { prepareTestTransaction, useJsonFixture } from '../_helpers'
 
-const CHAIN_ID = 'hedera:testnet'
+const CHAIN_ID = networkNameToCAIPChainId('testnet')
 const TOPIC = 'abcdef123456'
 
 describe(HederaSessionRequest.name, () => {
@@ -28,13 +28,12 @@ describe(HederaSessionRequest.name, () => {
 
   describe('buildSignAndExecuteTransactionRequest', () => {
     it(`should build request with ${HederaJsonRpcMethods.SIGN_AND_EXECUTE_TRANSACTION} params`, () => {
-      const type = RequestType.ConsensusCreateTopic
       const transaction = prepareTestTransaction(new TopicCreateTransaction())
 
       const result = HederaSessionRequest.create({
         chainId: CHAIN_ID,
         topic: TOPIC,
-      }).buildSignAndExecuteTransactionRequest(type, transaction)
+      }).buildSignAndExecuteTransactionRequest('0.0.1234', transaction)
 
       const expected = {
         chainId: CHAIN_ID,
@@ -58,7 +57,7 @@ describe(HederaSessionRequest.name, () => {
       const result = HederaSessionRequest.create({
         chainId: CHAIN_ID,
         topic: TOPIC,
-      }).buildSignAndReturnTransactionRequest(type, transaction)
+      }).buildSignAndReturnTransactionRequest('0.0.1234', transaction)
 
       const expected = {
         chainId: CHAIN_ID,
@@ -79,7 +78,7 @@ describe(HederaSessionRequest.name, () => {
       const result = HederaSessionRequest.create({
         chainId: CHAIN_ID,
         topic: TOPIC,
-      }).buildSignMessageRequest('Test me')
+      }).buildSignMessageRequest('0.0.1234', ['Test me'])
 
       const expected = {
         chainId: CHAIN_ID,

--- a/test/dapp/dapp-utils.test.ts
+++ b/test/dapp/dapp-utils.test.ts
@@ -1,15 +1,15 @@
-import { RequestType, TopicCreateTransaction, TopicDeleteTransaction } from '@hashgraph/sdk'
+import { TopicCreateTransaction, TopicDeleteTransaction } from '@hashgraph/sdk'
 import {
   buildSignAndExecuteTransactionParams,
   buildSignAndReturnTransactionParams,
   buildSignMessageParams,
 } from '../../src'
-import { prepareTestTransaction, useJsonFixture, writeJsonFixture } from '../_helpers'
+import { prepareTestTransaction, useJsonFixture } from '../_helpers'
 
 describe(buildSignMessageParams.name, () => {
   it('should build params with base64 encoded message', () => {
     const msg = 'Test me'
-    const result = buildSignMessageParams(msg)
+    const result = buildSignMessageParams('0.0.1234', [msg])
     const expected = useJsonFixture('buildSignMessageParamsResult')
 
     expect(result).toEqual(expected)
@@ -18,10 +18,9 @@ describe(buildSignMessageParams.name, () => {
 
 describe(buildSignAndExecuteTransactionParams.name, () => {
   it('should build transaction params with type and bytes', () => {
-    const type = RequestType.ConsensusCreateTopic
     const transaction = prepareTestTransaction(new TopicCreateTransaction())
 
-    const result = buildSignAndExecuteTransactionParams(type, transaction)
+    const result = buildSignAndExecuteTransactionParams('0.0.1234', transaction)
     const expected = useJsonFixture('buildSignAndExecuteTransactionParamsResult')
 
     expect(result).toEqual(expected)
@@ -30,10 +29,9 @@ describe(buildSignAndExecuteTransactionParams.name, () => {
 
 describe(buildSignAndReturnTransactionParams.name, () => {
   it('should build transaction params with type and bytes', () => {
-    const type = RequestType.ConsensusDeleteTopic
     const transaction = prepareTestTransaction(new TopicDeleteTransaction())
 
-    const result = buildSignAndReturnTransactionParams(type, transaction)
+    const result = buildSignAndReturnTransactionParams('0.0.1234', transaction)
     const expected = useJsonFixture('buildSignAndReturnTransactionParamsResult')
 
     expect(result).toEqual(expected)

--- a/test/wallet/wallet-signAndReturnTransaction.test.ts
+++ b/test/wallet/wallet-signAndReturnTransaction.test.ts
@@ -1,4 +1,4 @@
-import { RequestType, TopicCreateTransaction } from '@hashgraph/sdk'
+import { TopicCreateTransaction } from '@hashgraph/sdk'
 import { HederaWallet } from '../../src'
 import {
   defaultAccountNumber,
@@ -17,10 +17,7 @@ describe(HederaWallet.name, () => {
       })
       const transaction = prepareTestTransaction(new TopicCreateTransaction(), { freeze: true })
 
-      const result = await wallet.signAndReturnTransaction(
-        transaction,
-        RequestType.ConsensusCreateTopic.toString(),
-      )
+      const result = await wallet.signAndReturnTransaction(transaction)
       const expected = useJsonFixture('signAndReturnTransactionSuccess')
       expect(result).toEqual(expected)
     })

--- a/test/wallet/wallet-signMessage.test.ts
+++ b/test/wallet/wallet-signMessage.test.ts
@@ -25,8 +25,8 @@ describe(HederaWallet.name, () => {
           privateKey,
         })
         const messageBytes = Buffer.from('Hello world').toString('base64')
-        const result = wallet.signMessage(messageBytes)
-        expect(result.signature).toEqual(expected)
+        const result = wallet.signMessages([messageBytes])
+        expect(result.signatures[0]).toEqual(expected)
       },
     )
   })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     /* Visit https://aka.ms/tsconfig to read more about this file */
 
     /* Language and Environment */
-    "target": "es2022" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "target": "es5" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
@@ -18,9 +18,9 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "commonjs" /* Specify what module code is generated. */,
+    "module": "ESNext" /* Specify what module code is generated. */,
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    "moduleResolution": "node",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */


### PR DESCRIPTION
- Added chain id helpers
- Removed RequestType from HederaSessionRequest transaction parameters
- Added signerAccountId parameter to HederaSessionRequest parameters
- Made signMessages accept multiple messages instead of only one. This is more compatible with the `@hashgraph/sdk` Signer interface
- Updated readme
- Updated tests
- Updates tsconfig.json to support a broader set of modules