### PR TITLE
Update index.html

### DIFF
--- a/demo/src/index.html
+++ b/demo/src/index.html
@@ -17,7 +17,7 @@
   <body>
     <main>
       <!-- need to be on different host / port combinations https://github.com/WalletConnect/walletconnect-monorepo/issues/2975 -->
-      <iframe src="http://localhost:8080/dApp/index.html"></iframe>
+      <iframe src="/dApp/index.html"></iframe>
       <iframe src="http://localhost:8081/wallet/index.html"></iframe>
     </main>
   </body>


### PR DESCRIPTION
fixes the walletconnect modal not being able to be copied when not on the same domain

"localhost" vs "127.0.0.1"


https://github.com/hgraph-io/hedera-walletconnect-utils/assets/105378986/6ab9a84a-37ef-4d09-b434-26399a1b3989

