### PR TITLE
don't remove dist folder when using npm run dev to avoid race conditions

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,13 +44,13 @@
     "web3-utils": "^4.0.7"
   },
   "scripts": {
-    "build": "rm -Rf dist && npm run build:types && node scripts/lib/build.mjs",
+    "build": "npm run build:types && node scripts/lib/build.mjs",
     "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --outDir dist/types",
     "build:example": "node scripts/examples/build.mjs",
     "watch": "nodemon --watch src/lib/ --ext ts --exec \"npm run build\"",
-    "dev": "npm run build && concurrently --raw \"npm run watch\" \"node scripts/examples/dev.mjs\"",
+    "dev": "rm -Rf dist && npm run build && concurrently --raw \"npm run watch\" \"node scripts/examples/dev.mjs\"",
     "test": "jest",
     "test:connect": "jest --testMatch '**/DAppConnector.test.ts' --verbose",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "rm -Rf dist && npm run build"
   }
 }


### PR DESCRIPTION
previously we were removing the dist folder on every build.

as we're using a build on watching file changes for `npm run dev` this causes race conditions and periods of time when types are not available

developers will now need to restart `npm run dev` if they want to remove extra files that might have been deleted in the process of developing

closes #66 