### PR TITLE
test different request / response data structures

### DIFF
--- a/src/examples/typescript/dapp/index.html
+++ b/src/examples/typescript/dapp/index.html
@@ -181,13 +181,20 @@
             >
           </p>
 
-          <div>
+          <p>
             <i>
               Call <b>hedera_sendTransactionOnly</b> or
               <b>hedera_signTransactionAndSend</b> above with valid addresses before using
               simulating errors described below.</i
             >
-          </div>
+          </p>
+          <p>
+            See
+            <a href="https://specs.walletconnect.com/2.0/specs/clients/sign/error-codes"
+              >https://specs.walletconnect.com/2.0/specs/clients/sign/error-codes</a
+            >
+            for more information on WalletConnect error codes.
+          </p>
         </fieldset>
       </section>
       <section class="toggle">

--- a/src/lib/shared/errors.ts
+++ b/src/lib/shared/errors.ts
@@ -1,0 +1,42 @@
+//https://github.com/WalletConnect/walletconnect-monorepo/blob/v2.0/packages/utils/src/errors.ts
+export type HederaErrorKey = keyof typeof HEDERA_ERRORS
+
+// WalletConnect has certain error code ranges reserved for WalletConnect use
+// https://github.com/WalletConnect/walletconnect-monorepo/blob/v2.0/packages/utils/src/errors.ts
+// The following schema uses negative codes to avoid conflicts
+/*
+ * ErrorResponse
+ *   - JSON-RPC error can be a primitive or structured value that contains additional information about the error
+ *   however, ErrorResponse in WalletConnect is defined as a string, so we allow more robust error handling here
+ */
+export interface HederaErrorResponse<T = any> {
+  code: number
+  message: string
+  data?: T
+}
+
+export const HEDERA_ERRORS: { [key: string]: Pick<HederaErrorResponse, 'code' | 'message'> } = {
+  INVALID_PARAMS: {
+    code: -1,
+    message: 'INVALID_PARAMS',
+  },
+}
+
+export interface HederaJsonRpcError<T = any> {
+  id: number
+  jsonrpc: '2.0'
+  error: HederaErrorResponse<T>
+}
+
+export function getHederaError<T>(
+  key: string,
+  context?: string | number,
+  data?: T,
+): HederaErrorResponse<T> {
+  const { code, message } = HEDERA_ERRORS[key]
+  return {
+    code,
+    message: context ? `${message} ${context}` : message,
+    data,
+  }
+}

--- a/src/lib/shared/index.ts
+++ b/src/lib/shared/index.ts
@@ -1,4 +1,5 @@
 export * from './chainIds'
-export * from './methods'
 export * from './events'
+export * from './methods'
+export * from './payloads'
 export * from './utils'

--- a/src/lib/shared/index.ts
+++ b/src/lib/shared/index.ts
@@ -1,4 +1,5 @@
 export * from './chainIds'
+export * from './errors'
 export * from './events'
 export * from './methods'
 export * from './payloads'

--- a/src/lib/shared/payloads.ts
+++ b/src/lib/shared/payloads.ts
@@ -1,0 +1,49 @@
+import type {
+  TransactionResponse,
+  TransactionReceipt,
+  TransactionRecord,
+  AccountId,
+} from '@hashgraph/sdk'
+
+/*
+ * Transactions
+ */
+export type HederaTransactionRequest = {
+  signerAccountId: string // format of <shard>.<realm>.<account>, i.e. 0.0.12345
+  transaction: {
+    bytes: string // should be a base64 encoded Uint8Array
+  }
+  getReceipt?: boolean // defaults to true
+  getRecord?: boolean // defaults to false
+}
+
+export type HederaTransactionResponse = {
+  response: TransactionResponse
+  receipt?: TransactionReceipt
+  record?: TransactionRecord
+}
+
+/*
+ * Queries
+ */
+
+/*
+ * Messages
+ */
+
+export type HederaSignMessageRequest = {
+  signerAccountId: string
+  messages: string[] // base64 encoded string Uint8Array
+}
+
+export type HederaSignMessageResponse = {
+  signedMessages: string[]
+}
+
+/*
+ * Get node addresses
+ */
+export type HederaGetNodeAddressesResponse = {
+  consensus: { [key: string]: string | AccountId } // {hostname:port: AccountId}
+  mirror: string[] // string['hostname:port']
+}

--- a/src/lib/shared/payloads.ts
+++ b/src/lib/shared/payloads.ts
@@ -1,49 +1,57 @@
-import type {
-  TransactionResponse,
-  TransactionReceipt,
-  TransactionRecord,
-  AccountId,
-} from '@hashgraph/sdk'
+import type { TransactionResponseJSON } from '@hashgraph/sdk'
 
 /*
- * Transactions
- */
-export type HederaTransactionRequest = {
-  signerAccountId: string // format of <shard>.<realm>.<account>, i.e. 0.0.12345
-  transaction: {
-    bytes: string // should be a base64 encoded Uint8Array
-  }
-  getReceipt?: boolean // defaults to true
-  getRecord?: boolean // defaults to false
-}
-
-export type HederaTransactionResponse = {
-  response: TransactionResponse
-  receipt?: TransactionReceipt
-  record?: TransactionRecord
-}
-
-/*
- * Queries
+ * Request params
+ *
  */
 
-/*
- * Messages
- */
-
-export type HederaSignMessageRequest = {
+export type SignTransactionAndSendParams = {
   signerAccountId: string
-  messages: string[] // base64 encoded string Uint8Array
+  signedTransaction: string
 }
 
-export type HederaSignMessageResponse = {
+export type SendTransactionOnlyParams = {
+  signedTransaction: string
+}
+
+export type SignTransactionBodyParams = {
+  signerAccountId: string
+  transactionBody: string
+}
+
+export type GetNodeAddressesParams = undefined
+
+export type SignMessageParams = {
+  message: string
+}
+
+export type QueryParams = {
+  query: string
+}
+
+/*
+ * Responses
+ * {
+ *  "precheckCode": "<an integer representing the [ResponseCodeEnum] value returned from the Hedera Node, which may indicate success or failure.>",
+ *  "transactionId": "<a string encoded transaction identifier of the signed message that was sent to the Hedera node, in <shard>.<realm>.<number>@<seconds>.<nanos> format.>",
+ *  "nodeId": "<a string encoded transaction identifier of the Hedera Gossip Node’s Account that the transaction was submitted to, in <shard>.<realm>.<number> format>",
+ *  "transactionHash": "<base64 encoding of the SHA384 digest of the signedTransactionBytes of the Transaction message that was submitted to the Hedera Network.>"
+ * }
+ */
+
+export type SignTransactionAndSendResponse = TransactionResponseJSON & { precheckCode: number }
+
+export type SendTransactionOnlyResponse = TransactionResponseJSON & { precheckCode: number }
+
+export type SignTransactionBodyResponse = {
+  signatureMap: string //a base64 encoded string of the protobuf encoded Hedera API TransactionBody message
+}
+
+export type GetNodeAddressesResponse = { nodes: string[] }
+
+export type SignMessageResponse = {
   signedMessages: string[]
 }
-
-/*
- * Get node addresses
- */
-export type HederaGetNodeAddressesResponse = {
-  consensus: { [key: string]: string | AccountId } // {hostname:port: AccountId}
-  mirror: string[] // string['hostname:port']
+export type QueryResponse = {
+  response: string
 }

--- a/src/lib/shared/payloads.ts
+++ b/src/lib/shared/payloads.ts
@@ -1,57 +1,137 @@
+import { JsonRpcResult } from '@walletconnect/jsonrpc-types'
+import { EngineTypes } from '@walletconnect/types'
 import type { TransactionResponseJSON } from '@hashgraph/sdk'
+// import type { PrecheckStatusErrorJSON } from '@hashgraph/sdk/lib/PrecheckStatusError'
+import { HederaJsonRpcMethod } from './methods'
 
 /*
- * Request params
- *
+ * 1. hedera_getNodeAddresses
  */
+// params
+export type GetNodeAddressesParams = undefined
+// request
+export interface GetNodeAddressesRequest extends EngineTypes.RequestParams {
+  request: {
+    method: HederaJsonRpcMethod.GetNodeAddresses
+    params: GetNodeAddressesParams
+  }
+}
+// result
+export interface GetNodeAddressesResult extends JsonRpcResult<{ nodes: string[] }> {}
+// response
+export interface GetNodeAddresesResponse extends EngineTypes.RespondParams {
+  response: GetNodeAddressesResult
+}
 
-export type SignTransactionAndSendParams = {
+/*
+ * 2. hedera_sendTransactionOnly
+ */
+// params
+export interface SendTransactionOnlyParams {
+  signedTransaction: string
+}
+// request
+export interface SendTransactionOnlyRequest extends EngineTypes.RequestParams {
+  request: {
+    method: HederaJsonRpcMethod.SendTransactionOnly
+    params: SendTransactionOnlyParams
+  }
+}
+// result
+export interface SendTransactionOnlyResult
+  extends JsonRpcResult<TransactionResponseJSON & { precheckCode: number }> {}
+// response
+export interface SendTransactionOnlyResponse extends EngineTypes.RespondParams {
+  response: SendTransactionOnlyResult
+}
+
+/*
+ * 3. hedera_signMessage
+ */
+// params
+export interface SignMessageParams {
+  signerAccountId: string
+  message: string
+}
+// request
+export interface SignMessageRequest extends EngineTypes.RequestParams {
+  request: {
+    method: HederaJsonRpcMethod.SignMessage
+    params: SignMessageParams
+  }
+}
+// result
+export interface SignMessageResult extends JsonRpcResult<{ signatureMap: string }> {}
+// response
+export interface SignMessageResponse extends EngineTypes.RespondParams {
+  response: SignMessageResult
+}
+
+/*
+ * 4. hedera_signQueryAndSend
+ */
+// request
+export interface SignQueryAndSendRequest extends EngineTypes.RequestParams {
+  request: {
+    method: HederaJsonRpcMethod.SignQueryAndSend
+    params: {
+      signerAccountId: string
+      query: string
+    }
+  }
+}
+// result
+export interface SignQueryAndSendResult extends JsonRpcResult<{ response: string }> {}
+// response
+export interface SignQueryAndSendResponse extends EngineTypes.RespondParams {
+  response: SignQueryAndSendResult
+}
+
+/*
+ * 5. hedera_signTransactionAndSend
+ */
+// params
+export interface SignTransactionAndSendParams {
   signerAccountId: string
   signedTransaction: string
 }
-
-export type SendTransactionOnlyParams = {
-  signedTransaction: string
+// request
+export interface SignTransactionAndSendRequest extends EngineTypes.RequestParams {
+  request: {
+    method: HederaJsonRpcMethod.SignTransactionAndSend
+    params: SignTransactionAndSendParams
+  }
 }
 
-export type SignTransactionBodyParams = {
+// result
+export interface SignTransactionAndSendResult
+  extends JsonRpcResult<TransactionResponseJSON & { precheckCode: number }> {}
+
+// response
+export interface SignTransactionAndSendResponse extends EngineTypes.RespondParams {
+  response: SignTransactionAndSendResult
+}
+/*
+ * 6. hedera_signTransactionBody
+ */
+// params
+export interface SignTransactionBodyParams {
   signerAccountId: string
   transactionBody: string
 }
 
-export type GetNodeAddressesParams = undefined
-
-export type SignMessageParams = {
-  message: string
+//request
+export interface SignTransactionBodyRequest extends EngineTypes.RequestParams {
+  request: {
+    method: HederaJsonRpcMethod.SignTransactionBody
+    params: SignTransactionBodyParams
+  }
 }
 
-export type QueryParams = {
-  query: string
-}
+// result
+export interface SignTransactionBodyResult extends JsonRpcResult<{ signatureMap: string }> {}
 
-/*
- * Responses
- * {
- *  "precheckCode": "<an integer representing the [ResponseCodeEnum] value returned from the Hedera Node, which may indicate success or failure.>",
- *  "transactionId": "<a string encoded transaction identifier of the signed message that was sent to the Hedera node, in <shard>.<realm>.<number>@<seconds>.<nanos> format.>",
- *  "nodeId": "<a string encoded transaction identifier of the Hedera Gossip Node’s Account that the transaction was submitted to, in <shard>.<realm>.<number> format>",
- *  "transactionHash": "<base64 encoding of the SHA384 digest of the signedTransactionBytes of the Transaction message that was submitted to the Hedera Network.>"
- * }
- */
-
-export type SignTransactionAndSendResponse = TransactionResponseJSON & { precheckCode: number }
-
-export type SendTransactionOnlyResponse = TransactionResponseJSON & { precheckCode: number }
-
-export type SignTransactionBodyResponse = {
-  signatureMap: string //a base64 encoded string of the protobuf encoded Hedera API TransactionBody message
-}
-
-export type GetNodeAddressesResponse = { nodes: string[] }
-
-export type SignMessageResponse = {
-  signedMessages: string[]
-}
-export type QueryResponse = {
-  response: string
+// response
+export interface SignTransactionBodyResponse extends EngineTypes.RespondParams {
+  response: SignTransactionBodyResult
 }

--- a/src/lib/wallet/index.ts
+++ b/src/lib/wallet/index.ts
@@ -207,16 +207,10 @@ export default class Wallet extends Web3Wallet implements HederaNativeWallet {
   public async hedera_signTransactionAndSend(
     id: number,
     topic: string,
-    body: Transaction,
+    body: Transaction, // can be signed or unsigned
     signer: HederaWallet,
   ): Promise<void> {
-    let result
-    try {
-      const result = await signer.call(await signer.signTransaction(body))
-      console.log('result: ', result)
-    } catch (e) {
-      console.error(e)
-    }
+    const result = await signer.call(await signer.signTransaction(body))
 
     return await this.respondSessionRequest({
       topic,

--- a/src/lib/wallet/index.ts
+++ b/src/lib/wallet/index.ts
@@ -238,7 +238,6 @@ export default class Wallet extends Web3Wallet implements HederaNativeWallet {
     signer: HederaWallet,
   ): Promise<void> {
     const result = signer.getNetwork()
-    // const mirror = signer.getMirrorNetwork()
 
     return await this.respondSessionRequest({
       topic,

--- a/src/lib/wallet/index.ts
+++ b/src/lib/wallet/index.ts
@@ -3,7 +3,6 @@ import { Web3Wallet, Web3WalletTypes } from '@walletconnect/web3wallet'
 import { SessionTypes } from '@walletconnect/types'
 import { buildApprovedNamespaces } from '@walletconnect/utils'
 import { Wallet as HederaWallet, Client, AccountId, Transaction, Query } from '@hashgraph/sdk'
-// import type { HederaTransactionRequest, HederaTransactionResponse } from '../shared'
 import {
   HederaChainId,
   HederaSessionEvent,

--- a/src/lib/wallet/index.ts
+++ b/src/lib/wallet/index.ts
@@ -3,7 +3,7 @@ import { Web3Wallet, Web3WalletTypes } from '@walletconnect/web3wallet'
 import { SessionTypes } from '@walletconnect/types'
 import { buildApprovedNamespaces } from '@walletconnect/utils'
 import { Wallet as HederaWallet, Client, AccountId, Transaction, Query } from '@hashgraph/sdk'
-import type { HederaTransactionRequest, HederaTransactionResponse } from '../shared'
+// import type { HederaTransactionRequest, HederaTransactionResponse } from '../shared'
 import {
   HederaChainId,
   HederaSessionEvent,
@@ -210,7 +210,13 @@ export default class Wallet extends Web3Wallet implements HederaNativeWallet {
     body: Transaction,
     signer: HederaWallet,
   ): Promise<void> {
-    const result = await signer.call(await signer.signTransaction(body))
+    let result
+    try {
+      const result = await signer.call(await signer.signTransaction(body))
+      console.log('result: ', result)
+    } catch (e) {
+      console.error(e)
+    }
 
     return await this.respondSessionRequest({
       topic,

--- a/src/lib/wallet/index.ts
+++ b/src/lib/wallet/index.ts
@@ -3,6 +3,7 @@ import { Web3Wallet, Web3WalletTypes } from '@walletconnect/web3wallet'
 import { SessionTypes } from '@walletconnect/types'
 import { buildApprovedNamespaces } from '@walletconnect/utils'
 import { Wallet as HederaWallet, Client, AccountId, Transaction, Query } from '@hashgraph/sdk'
+import type { HederaTransactionRequest, HederaTransactionResponse } from '../shared'
 import {
   HederaChainId,
   HederaSessionEvent,
@@ -206,7 +207,7 @@ export default class Wallet extends Web3Wallet implements HederaNativeWallet {
   public async hedera_signTransactionAndSend(
     id: number,
     topic: string,
-    body: Transaction, // can be signed or unsigned
+    body: Transaction,
     signer: HederaWallet,
   ): Promise<void> {
     const result = await signer.call(await signer.signTransaction(body))
@@ -238,6 +239,7 @@ export default class Wallet extends Web3Wallet implements HederaNativeWallet {
     signer: HederaWallet,
   ): Promise<void> {
     const result = signer.getNetwork()
+    // const mirror = signer.getMirrorNetwork()
 
     return await this.respondSessionRequest({
       topic,


### PR DESCRIPTION
This PR adds 4 types for each JSON-RPC method.

- Requests: have a `topic`,  `chainId`, `expiry` & `method` + `params`;
- Params are grouped to show their pertinent payload: params have a type of `method` and `params`

- Response: have a `topic` and `response` sent back to a requester
- Result: a typed `result` depending on the method

This PR also adds error types:
- we can use errors to handle the conditional response of either the successful "response" above OR a error payload